### PR TITLE
feat: Add WorkloadIdentity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `WorkloadIdentity` resource for AKS provider.
+
 ## [0.1.1] - 2026-03-16
 
 ### Changed

--- a/helm/cert-manager-crossplane-resources/templates/_helpers.tpl
+++ b/helm/cert-manager-crossplane-resources/templates/_helpers.tpl
@@ -69,3 +69,10 @@ Check if Azure is properly configured
 {{- false -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Determine the resource group name to use.
+*/}}
+{{- define "azure.resourceGroupName" -}}
+{{ .Values.providers.azure.resourceGroup | default .Values.clusterName }}
+{{- end -}}

--- a/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
+++ b/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
@@ -14,13 +14,13 @@ spec:
   subject: system:serviceaccount:kube-system:cert-manager-app
   subscriptionID: {{ .Values.providers.azure.subscriptionId }}
   template: |
-      cert-manager:
-        giantSwarmClusterIssuer:
-          acme:
-            dns01:
-              azureDNS:
-                identityClientID: "${clientID}"
+      giantSwarmClusterIssuer:
+        acme:
+          dns01:
+            azureDNS:
+              identityClientID: "${clientID}"
 
+      cert-manager:
         extraObjects:
           - |
             apiVersion: v1

--- a/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
+++ b/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
@@ -1,0 +1,16 @@
+{{- if eq .Values.provider "aks" }}
+apiVersion: crossplane.giantswarm.io/v1alpha1
+kind: WorkloadIdentity
+metadata:
+  name: {{ .Values.clusterName }}-crossplane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  clusterName: {{ .Values.clusterName }}
+  provider: {{ .Values.provider }}
+  location: {{ .Values.providers.azure.location }}
+  resourceGroupName: {{ .Values.providers.azure.resourceGroup }}
+  subject: system:serviceaccount:kube-system:cert-manager-app
+  subscriptionID: {{ .Values.providers.azure.subscriptionId }}
+{{- end }}

--- a/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
+++ b/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
@@ -15,6 +15,12 @@ spec:
   subscriptionID: {{ .Values.providers.azure.subscriptionId }}
   template: |
       cert-manager:
+        giantSwarmClusterIssuer:
+          acme:
+            dns01:
+              azureDNS:
+                identityClientID: "${clientID}"
+
         extraObjects:
           - |
             apiVersion: v1

--- a/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
+++ b/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
@@ -27,7 +27,7 @@ spec:
             kind: ConfigMap
             metadata:
               name: cert-manager-identity
-              namespace: {{ .Release.Namespace }}
+              namespace: kube-system
               labels:
                 {{- include "labels.common" . | nindent 16 }}
             data:

--- a/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
+++ b/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
@@ -10,7 +10,7 @@ spec:
   clusterName: {{ .Values.clusterName }}
   provider: {{ .Values.provider }}
   location: {{ .Values.providers.azure.location }}
-  resourceGroupName: {{ .Values.providers.azure.resourceGroup }}
+  resourceGroupName: {{ include "azure.resourceGroupName" . }}
   subject: system:serviceaccount:kube-system:cert-manager-app
   subscriptionID: {{ .Values.providers.azure.subscriptionId }}
 {{- end }}

--- a/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
+++ b/helm/cert-manager-crossplane-resources/templates/providers/aks.yaml
@@ -2,7 +2,7 @@
 apiVersion: crossplane.giantswarm.io/v1alpha1
 kind: WorkloadIdentity
 metadata:
-  name: {{ .Values.clusterName }}-crossplane
+  name: {{ .Values.clusterName }}-cert-manager
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -13,4 +13,18 @@ spec:
   resourceGroupName: {{ include "azure.resourceGroupName" . }}
   subject: system:serviceaccount:kube-system:cert-manager-app
   subscriptionID: {{ .Values.providers.azure.subscriptionId }}
+  template: |
+      cert-manager:
+        extraObjects:
+          - |
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: cert-manager-identity
+              namespace: {{ .Release.Namespace }}
+              labels:
+                {{- include "labels.common" . | nindent 16 }}
+            data:
+              clientID: "${clientID}"
+              tenantID: "${tenantID}"
 {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36640.

Adds a WorkloadIdentity resource: a Crossplane composition that sets up Azure Workload Identity for a service account and publishes a ConfigMap with Helm values for merging into a HelmRelease or App.

It is currently only supported on AKS clusters, but will be used for CAPZ clusters once we build support for automated workload identity.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.